### PR TITLE
Fix/string preferences jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <!-- Properties -->
     <properties>
-        <revision>0.9.1</revision>
+        <revision>0.9.2</revision>
         <java-version>21</java-version>
         <jdk-version>21</jdk-version>
         <enforcer.jdk-version>[${jdk-version},)</enforcer.jdk-version>

--- a/src/integration-test/java/org/viewer/hub/back/controller/PreferenceControllerIntegrationTests.java
+++ b/src/integration-test/java/org/viewer/hub/back/controller/PreferenceControllerIntegrationTests.java
@@ -153,7 +153,7 @@ class PreferenceControllerIntegrationTests {
 				.param("user", "user")
 				.param("profile", "default")
 				.param("module", "weasis")
-				.accept(MediaType.APPLICATION_XML_VALUE))
+				.accept(MediaType.TEXT_PLAIN_VALUE))
 			.andExpect(MockMvcResultMatchers.status().isOk())
 			.andExpect(MockMvcResultMatchers.content().string("weasis"));
 	}
@@ -187,7 +187,7 @@ class PreferenceControllerIntegrationTests {
 				.param("user", "")
 				.param("profile", "")
 				.param("module", "")
-				.accept(MediaType.APPLICATION_XML_VALUE))
+				.accept(MediaType.TEXT_PLAIN_VALUE))
 			.andExpect(MockMvcResultMatchers.status().isBadRequest());
 	}
 
@@ -288,7 +288,7 @@ class PreferenceControllerIntegrationTests {
 				.param("user", "user")
 				.param("profile", "default")
 				.param("module", "weasis")
-				.contentType(MediaType.APPLICATION_XML_VALUE)
+				.contentType(MediaType.TEXT_PLAIN_VALUE)
 				.content("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><preferences></preferences>"))
 			.andExpect(MockMvcResultMatchers.status().isCreated());
 	}
@@ -323,7 +323,7 @@ class PreferenceControllerIntegrationTests {
 				.param("user", "")
 				.param("profile", "")
 				.param("module", "")
-				.contentType(MediaType.APPLICATION_XML_VALUE))
+				.contentType(MediaType.TEXT_PLAIN_VALUE))
 			.andExpect(MockMvcResultMatchers.status().isBadRequest());
 	}
 

--- a/src/main/java/org/viewer/hub/back/controller/PreferenceController.java
+++ b/src/main/java/org/viewer/hub/back/controller/PreferenceController.java
@@ -32,6 +32,7 @@ import org.viewer.hub.back.enums.OperationType;
 import org.viewer.hub.back.service.ApplicationPreferenceService;
 
 import java.sql.SQLException;
+import java.util.Locale;
 
 /**
  * Resource class for Weasis Preferences (application and modules)
@@ -102,7 +103,7 @@ public class PreferenceController {
 	 * @return the Weasis module preferences for a given user as well as for a given
 	 * Weasis profile and a Weasis module
 	 */
-	@GetMapping(produces = { MediaType.APPLICATION_XML_VALUE })
+	@GetMapping(produces = { MediaType.TEXT_PLAIN_VALUE })
 	public ResponseEntity<String> getWeasisPreferences(@RequestParam(value = PARAM_USER, required = false) String user,
 			@RequestParam(value = PARAM_PROFILE, required = false) String profile,
 			@RequestParam(value = PARAM_MODULE, required = false) String module) throws SQLException {
@@ -182,12 +183,12 @@ public class PreferenceController {
 	 * @param is Weasis module preferences to store
 	 * @return ResponseEntity<String>
 	 */
-	@PostMapping(consumes = { MediaType.APPLICATION_XML_VALUE })
+	@PostMapping(consumes = { MediaType.TEXT_PLAIN_VALUE })
 	public ResponseEntity<String> updateWeasisPreferences(
 			@RequestParam(value = PARAM_USER, required = false) String user,
 			@RequestParam(value = PARAM_PROFILE, required = false) String profile,
-			@RequestParam(value = PARAM_MODULE, required = false) String module, @RequestBody String preferences)
-			throws SQLException {
+			@RequestParam(value = PARAM_MODULE, required = false) String module,
+			@RequestBody @NotBlank String preferences) throws SQLException {
 		LOG.debug("updateWeasisPreferences");
 		ResponseEntity<String> response = null;
 
@@ -198,6 +199,11 @@ public class PreferenceController {
 
 		if (userIsEmpty && profileIsEmpty && moduleIsEmpty) {
 			throw new ParameterException("User, profile and module are empty");
+		}
+
+		// Force user to uppercase
+		if (!userIsEmpty) {
+			user = user.toUpperCase(Locale.ROOT);
 		}
 
 		OperationType operationType = this.applicationPreferenceService.updateWeasisPreferences(user, profile, module,


### PR DESCRIPTION
Fix preferences endpoints. 
As preferences should remain generic and there are no modification made on preferences by viewer-hub, a String is stored in DB (and not an object).
Thus modification of consumes/produces to text/plain for the preferences endpoints.

